### PR TITLE
Use `six.moves.http_client` instead of `httplib`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 sudo: false
 
+before_install:
+- sudo apt-get install -y libssl-dev
+
 install:
 - pip install tox coveralls
 

--- a/httplib2shim/__init__.py
+++ b/httplib2shim/__init__.py
@@ -28,8 +28,8 @@ import warnings
 
 import certifi
 import httplib2
-import urllib3
 import six.moves.http_client
+import urllib3
 
 def _default_make_pool(http, proxy_info):
     """Creates a urllib3.PoolManager object that has SSL verification enabled

--- a/httplib2shim/__init__.py
+++ b/httplib2shim/__init__.py
@@ -31,6 +31,7 @@ import httplib2
 import six.moves.http_client
 import urllib3
 
+
 def _default_make_pool(http, proxy_info):
     """Creates a urllib3.PoolManager object that has SSL verification enabled
     and uses the certifi certificates."""

--- a/httplib2shim/__init__.py
+++ b/httplib2shim/__init__.py
@@ -22,7 +22,6 @@
 
 import collections
 import errno
-import httplib
 import socket
 import ssl
 import warnings
@@ -30,7 +29,7 @@ import warnings
 import certifi
 import httplib2
 import urllib3
-
+import six.moves.http_client
 
 def _default_make_pool(http, proxy_info):
     """Creates a urllib3.PoolManager object that has SSL verification enabled
@@ -122,7 +121,7 @@ class Http(httplib2.Http):
     @classmethod
     def _create_full_uri(cls, conn, request_uri):
         # Reconstruct the full uri from the connection object.
-        if isinstance(conn, httplib.HTTPSConnection):
+        if isinstance(conn, six.moves.http_client.HTTPSConnection):
             scheme = 'https'
         else:
             scheme = 'http'

--- a/httplib2shim/test/httplib2_test.py
+++ b/httplib2shim/test/httplib2_test.py
@@ -25,7 +25,6 @@ This is the httplib2 test suite. It has been adapted to use the shim and to
 run on both python 2 and python 3.
 """
 
-import httplib
 import io
 import os
 import pickle
@@ -39,6 +38,7 @@ import unittest
 import httplib2
 import httplib2shim
 import six
+import six.moves.http_client
 from six.moves.urllib import parse as urllib_parse
 import urllib3
 
@@ -115,7 +115,7 @@ class CreateFullUriTest(unittest.TestCase):
         self.assertEqual(
             "http://example.com:8080/mypath",
             httplib2.Http._create_full_uri(
-                conn=httplib.HTTPConnection(
+                conn=six.moves.http_client.HTTPConnection(
                     host="example.com", port=8080),
                 request_uri="/mypath"))
         self.assertEqual(
@@ -135,7 +135,7 @@ class CreateFullUriTest(unittest.TestCase):
         self.assertEqual(
             "http://example.com:80/mypath",
             httplib2.Http._create_full_uri(
-                conn=httplib.HTTPConnection(
+                conn=six.moves.http_client.HTTPConnection(
                     host="example.com"),
                 request_uri="/mypath"))
         self.assertEqual(
@@ -152,7 +152,7 @@ class CreateFullUriTest(unittest.TestCase):
                 request_uri="/mypath"))
 
     def testHttpWithNonePort(self):
-        conn = httplib.HTTPConnection(host="example.com")
+        conn = six.moves.http_client.HTTPConnection(host="example.com")
         conn.port = None
         self.assertEqual(
             "http://example.com/mypath",
@@ -178,7 +178,7 @@ class CreateFullUriTest(unittest.TestCase):
         self.assertEqual(
             "https://example.com:8443/mypath",
             httplib2.Http._create_full_uri(
-                conn=httplib.HTTPSConnection(
+                conn=six.moves.http_client.HTTPSConnection(
                     host="example.com", port=8443),
                 request_uri="/mypath"))
         self.assertEqual(
@@ -198,7 +198,7 @@ class CreateFullUriTest(unittest.TestCase):
         self.assertEqual(
             "https://example.com:443/mypath",
             httplib2.Http._create_full_uri(
-                conn=httplib.HTTPSConnection(
+                conn=six.moves.http_client.HTTPSConnection(
                     host="example.com"),
                 request_uri="/mypath"))
         self.assertEqual(
@@ -215,7 +215,7 @@ class CreateFullUriTest(unittest.TestCase):
                 request_uri="/mypath"))
 
     def testHttpsWithNonePort(self):
-        conn = httplib.HTTPSConnection(host="example.com")
+        conn = six.moves.http_client.HTTPSConnection(host="example.com")
         conn.port = None
         self.assertEqual(
             "https://example.com/mypath",


### PR DESCRIPTION
`httplib` has been renamed to `http.client` in Python 3.
https://docs.python.org/2/library/httplib.html

`six.moves.http_client` works for both Python 2 and 3.